### PR TITLE
remove kiss_fft build from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-SOURCES = $(wildcard src/*.cpp) kissfft/kiss_fft.c
+SOURCES = $(wildcard src/*.cpp)
 
 include ../../plugin.mk
 


### PR DESCRIPTION
It is not included in this repository. Having this in the Makefile breaks the build.