### PR TITLE
Improved VCF HP output and added proposal for a BP output

### DIFF
--- a/src/VCF.cpp
+++ b/src/VCF.cpp
@@ -140,7 +140,8 @@ void VCF::step() {
 
 	// Set outputs
 	outputs[LPF_OUTPUT].value = 5.0f * filter.state[3];
-	outputs[HPF_OUTPUT].value = 5.0f * (input - filter.state[3]);
+	outputs[HPF_OUTPUT].value = 5.0f * (input - 4*filter.state[0] + 6*filter.state[1] - 4*filter.state[2] + filter.state[3]);
+	//outputs[BPF_OUTPUT].value = 5.0f * (filter.state[1] - 2*filter.state[2] + filter.state[3]);
 }
 
 


### PR DESCRIPTION
I have replaced the previous Fundamental VCF HP output formula with the correct one, and I have added a commented instruction which could be used to provide a BP output as well if wanted.

Note : I have not tested yet the submitted change, but these formulas are the one I use all the time in my own Moog-like / transistor ladder filter algorithms, such as the one in Sonic Academy ANA 2.

For more information about the formula I have used, see there : http://www.kvraudio.com/forum/viewtopic.php?t=207647